### PR TITLE
Theduckcow update

### DIFF
--- a/src/blender-text-counter.py
+++ b/src/blender-text-counter.py
@@ -223,6 +223,9 @@ def textcounter_update_val(text, scene):
     out = ''
     neg=''
     
+    if props.ifAnimated == False:
+        return # don't modify if disabled
+    
     if props.typeEnum == 'ANIMATED':
         counter = props.counter
     elif props.typeEnum == 'DYNAMIC':


### PR DESCRIPTION
Created additional options for text counters.

**Added:**
- Support for using commas
- Support for swapping commas and decimals (e.g. 1,000.12 vs 1.000,12)
- Support for basic number abbreviations ( e.g. 1000 becomes 1K)

**Key notes:**
- Padding now works slightly differently, it will pad based on the number of digits (including decimals) instead of just based on number of digits in front of a decimal.
- Odd bug which is an artifact of how the .format function is implemented, if commas and padding is used: any commas (e.g. the 2 commas in 00,000,000) will count as part of the padding, ie that number requires a padding value of 10 and not 8 as you would expect; when you disable commas it returns to normal (ie 00000000 is padding value 8).

**Video demo:**
![screen shot 2017-02-19 at 10 04 11 pm](https://cloud.githubusercontent.com/assets/2958461/23110433/6200cbbc-f6ef-11e6-9f7f-7fae0365295d.png)
